### PR TITLE
Load database properties for AppConfig

### DIFF
--- a/src/main/java/com/example/orders/config/AppConfig.java
+++ b/src/main/java/com/example/orders/config/AppConfig.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -18,6 +19,7 @@ import javax.sql.DataSource;
 @Configuration
 @ComponentScan(basePackages = "com.example.orders")
 @EnableTransactionManagement
+@PropertySource("classpath:application.properties")
 public class AppConfig {
 
     @Value("${db.url}")


### PR DESCRIPTION
## Summary
- add PropertySource annotation to load DB settings from application.properties

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6f325b008327968d7a54e3bfac37