### PR TITLE
Use ParameterMessageInterpolator instead of default EL-based interpolator

### DIFF
--- a/src/main/java/com/example/orders/config/AppConfig.java
+++ b/src/main/java/com/example/orders/config/AppConfig.java
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -53,6 +54,10 @@ public class AppConfig {
 
     @Bean
     public Validator validator() {
-        return Validation.buildDefaultValidatorFactory().getValidator();
+        return Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory()
+                .getValidator();
     }
 }


### PR DESCRIPTION
## Summary
- configure Validator bean with ParameterMessageInterpolator to avoid requiring EL implementation

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf7369624832797785b35637443dc